### PR TITLE
feat #1: 사용자 등록 API 구현 & Spring Security 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,9 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### QueryDSL: QClass path
+generated/
+
+### Mac OS
+.DS_Store

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/config/SecurityConfig.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/config/SecurityConfig.java
@@ -1,0 +1,48 @@
+package com.wanted.teamr.tastyfinder.api.config;
+
+import static org.springframework.boot.autoconfigure.security.servlet.PathRequest.toH2Console;
+import static org.springframework.security.config.Customizer.withDefaults;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests(authorizeHttpRequest -> authorizeHttpRequest
+                        .requestMatchers(new AntPathRequestMatcher("/api/**")).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
+                .csrf(csrf -> csrf
+                        .ignoringRequestMatchers(toH2Console())
+                        .disable()
+                )
+                .formLogin(AbstractHttpConfigurer::disable)
+                .sessionManagement(sessionManager -> sessionManager.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .httpBasic(withDefaults());
+        return http.build();
+    }
+}

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/config/SecurityConfig.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/config/SecurityConfig.java
@@ -15,7 +15,6 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Configuration
 @EnableWebSecurity
@@ -32,7 +31,7 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .authorizeHttpRequests(authorizeHttpRequest -> authorizeHttpRequest
-                        .requestMatchers(new AntPathRequestMatcher("/api/**")).permitAll()
+                        .requestMatchers("/api/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
@@ -41,8 +40,7 @@ public class SecurityConfig {
                         .disable()
                 )
                 .formLogin(AbstractHttpConfigurer::disable)
-                .sessionManagement(sessionManager -> sessionManager.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .httpBasic(withDefaults());
+                .sessionManagement(sessionManager -> sessionManager.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
         return http.build();
     }
 }

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/member/controller/MemberController.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/member/controller/MemberController.java
@@ -1,0 +1,24 @@
+package com.wanted.teamr.tastyfinder.api.member.controller;
+
+import com.wanted.teamr.tastyfinder.api.member.dto.MemberCreateRequest;
+import com.wanted.teamr.tastyfinder.api.member.service.MemberService;
+import jakarta.validation.Valid;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/api/members")
+    public ResponseEntity<Void> createMember(@RequestBody @Valid MemberCreateRequest memberCreateRequest) {
+        Long memberId = memberService.createMember(memberCreateRequest);
+        return ResponseEntity.created(URI.create("/api/members/" + memberId)).build();
+    }
+}

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/member/domain/Member.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/member/domain/Member.java
@@ -1,0 +1,53 @@
+package com.wanted.teamr.tastyfinder.api.member.domain;
+
+import com.wanted.teamr.tastyfinder.api.member.dto.MemberCreateRequest;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.Email;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Entity
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Email
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    private Float latitude; //위도
+
+    private Float longitude; //경도
+
+    @Column(nullable = false)
+    private boolean isRecommendEnabled = false;
+
+    protected Member() {
+    }
+
+    @Builder
+    private Member(String email, String password, Float latitude, Float longitude, Boolean isRecommendEnabled) {
+        this.email = email;
+        this.password = password;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.isRecommendEnabled = isRecommendEnabled != null ? isRecommendEnabled : false;
+    }
+
+    public static Member from(MemberCreateRequest memberCreateRequest) {
+        return Member.builder()
+                .email(memberCreateRequest.getEmail())
+                .password(memberCreateRequest.getPassword())
+                .build();
+    }
+}

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/member/dto/MemberCreateRequest.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/member/dto/MemberCreateRequest.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 public class MemberCreateRequest {
 
     @NotBlank
-    @Email
+    @Email(regexp = "^[\\w!#$%&amp;'*+/=?`{|}~^-]+(?:\\.[\\w!#$%&amp;'*+/=?`{|}~^-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}$")
     private String email;
 
     @NotBlank

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/member/dto/MemberCreateRequest.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/member/dto/MemberCreateRequest.java
@@ -1,0 +1,18 @@
+package com.wanted.teamr.tastyfinder.api.member.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MemberCreateRequest {
+
+    @NotBlank
+    @Email
+    private String email;
+
+    @NotBlank
+    private String password;
+}

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/member/repository/MemberRepository.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/member/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.wanted.teamr.tastyfinder.api.member.repository;
+
+import com.wanted.teamr.tastyfinder.api.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/member/service/MemberService.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/member/service/MemberService.java
@@ -1,0 +1,21 @@
+package com.wanted.teamr.tastyfinder.api.member.service;
+
+import com.wanted.teamr.tastyfinder.api.member.domain.Member;
+import com.wanted.teamr.tastyfinder.api.member.dto.MemberCreateRequest;
+import com.wanted.teamr.tastyfinder.api.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public Long createMember(MemberCreateRequest memberCreateRequest) {
+        Member member = Member.from(memberCreateRequest);
+        return memberRepository.save(member).getId();
+    }
+}

--- a/src/test/java/com/wanted/teamr/tastyfinder/api/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/wanted/teamr/tastyfinder/api/member/controller/MemberControllerTest.java
@@ -1,0 +1,113 @@
+package com.wanted.teamr.tastyfinder.api.member.controller;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wanted.teamr.tastyfinder.api.member.dto.MemberCreateRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+class MemberControllerTest {
+
+    private final String testEmail = "test@test.com";
+    private final String testPassword = "12345678";
+    private final String requestUri = "/api/members";
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @Test
+    @WithMockUser
+    @DisplayName("사용자를 생성할 수 있다.")
+    void createMember() throws Exception {
+        //given
+        MemberCreateRequest memberCreateRequest = MemberCreateRequest.builder()
+                .email(testEmail)
+                .password(testPassword)
+                .build();
+
+        //when then
+        mockMvc.perform(post(requestUri)
+                        .accept(APPLICATION_JSON)
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(memberCreateRequest))
+                )
+                .andDo(print())
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("잘못된 이메일로 사용자를 생성할 수 없다.")
+    void createMember_invalidEmail() throws Exception {
+        //given
+        MemberCreateRequest memberCreateRequest = MemberCreateRequest.builder()
+                .email("test.com")
+                .password(testPassword)
+                .build();
+
+        //when then
+        mockMvc.perform(post(requestUri)
+                        .accept(APPLICATION_JSON)
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(memberCreateRequest))
+                )
+                .andDo(print())
+                //TODO: exception 처리 수정
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("이메일 없이 사용자를 생성할 수 없다.")
+    void createMember_emptyEmail() throws Exception {
+        //given
+        MemberCreateRequest memberCreateRequest = MemberCreateRequest.builder()
+                .password(testPassword)
+                .build();
+
+        //when then
+        mockMvc.perform(post(requestUri)
+                        .accept(APPLICATION_JSON)
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(memberCreateRequest))
+                )
+                .andDo(print())
+                //TODO: exception 처리 수정
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("비밀번호 없이 사용자를 생성할 수 없다.")
+    void createMember_emptyPassword() throws Exception {
+        //given
+        MemberCreateRequest memberCreateRequest = MemberCreateRequest.builder()
+                .email(testEmail)
+                .build();
+
+        //when then
+        mockMvc.perform(post(requestUri)
+                        .accept(APPLICATION_JSON)
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(memberCreateRequest))
+                )
+                .andDo(print())
+                //TODO: exception 처리 수정
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/wanted/teamr/tastyfinder/api/member/service/MemberServiceTest.java
+++ b/src/test/java/com/wanted/teamr/tastyfinder/api/member/service/MemberServiceTest.java
@@ -1,0 +1,95 @@
+package com.wanted.teamr.tastyfinder.api.member.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.wanted.teamr.tastyfinder.api.member.domain.Member;
+import com.wanted.teamr.tastyfinder.api.member.dto.MemberCreateRequest;
+import com.wanted.teamr.tastyfinder.api.member.repository.MemberRepository;
+import jakarta.validation.ConstraintViolationException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+class MemberServiceTest {
+
+    private final String testEmail = "test@test.com";
+    private final String testPassword = "12345678";
+
+    @Autowired
+    private MemberService memberService;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("사용자를 생성할 수 있다.")
+    void createMember() {
+        //given
+        MemberCreateRequest memberCreateRequest = MemberCreateRequest.builder()
+                .email(testEmail)
+                .password(testPassword)
+                .build();
+
+        //when
+        Long memberId = memberService.createMember(memberCreateRequest);
+
+        //then
+        Member findedMember = findMemberById(memberId);
+        assertThat(findedMember).isNotNull();
+        assertThat(findedMember.getEmail()).isEqualTo(memberCreateRequest.getEmail());
+    }
+
+    @Test
+    @DisplayName("잘못된 이메일로 사용자를 생성할 수 없다.")
+    void createMember_invalidEmail() {
+        //given
+        MemberCreateRequest memberCreateRequest = MemberCreateRequest.builder()
+                .email("invalidTest.com")
+                .password(testPassword)
+                .build();
+
+        //when then
+        assertThatThrownBy(() -> memberService.createMember(memberCreateRequest))
+                //TODO: exception 처리 수정
+                .isInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    @DisplayName("이메일 없이 사용자를 생성할 수 없다.")
+    void createMember_emptyEmail() {
+        //given
+        MemberCreateRequest memberCreateRequest = MemberCreateRequest.builder()
+                .password(testPassword)
+                .build();
+
+        //when then
+        assertThatThrownBy(() -> memberService.createMember(memberCreateRequest))
+                //TODO: exception 처리 수정
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    @DisplayName("비밀번호 없이 사용자를 생성할 수 없다.")
+    void createMember_emptyPassword() {
+        //given
+        MemberCreateRequest memberCreateRequest = MemberCreateRequest.builder()
+                .email(testEmail)
+                .build();
+
+        //when then
+        assertThatThrownBy(() -> memberService.createMember(memberCreateRequest))
+                //TODO: exception 처리 수정
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    private Member findMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                //TODO: exception 처리 수정
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+    }
+}


### PR DESCRIPTION
## 📃 설명

- resolves #1 
- 사용자 등록(=회원가입) API를 구현한다.
- Spring Security 설정을 추가한다.

## 🔨 작업 내용

1. Spring Security 설정
2. 사용자(Member) 엔티티 추가
3. 사용자 등록 기능 구현

## 💬 기타 사항

- Security 설정의 빠른 merge를 위해 exception 처리는 TODO로 올려놓고 추후 수정하겠습니다.
- 임시로 SecurityConfig 권한 관련된 부분은 모두 허용 처리해놨습니다. Role 관련 로직 구현대는 되로 수정하겠습니다.
- JWT는 다른 이슈로 생성해서 따로 처리할 예정입니다.
  - UserDetails 구현은 JWT 구현 시 함께 진행하겠습니다.