### PR TITLE
feat #2: 사용자 로그인(JWT) API 구현 

### DIFF
--- a/src/main/java/com/wanted/teamr/tastyfinder/api/auth/controller/AuthController.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/auth/controller/AuthController.java
@@ -1,0 +1,24 @@
+package com.wanted.teamr.tastyfinder.api.auth.controller;
+
+import com.wanted.teamr.tastyfinder.api.auth.dto.TokenCreateRequest;
+import com.wanted.teamr.tastyfinder.api.auth.dto.TokenCreateResponse;
+import com.wanted.teamr.tastyfinder.api.auth.service.AuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/api/auth/login")
+    public ResponseEntity<TokenCreateResponse> login(@RequestBody @Valid TokenCreateRequest tokenCreateRequest) {
+        TokenCreateResponse tokenCreateResponse = authService.login(tokenCreateRequest);
+        return ResponseEntity.ok().body(tokenCreateResponse);
+    }
+}

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/auth/domain/MemberAdapter.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/auth/domain/MemberAdapter.java
@@ -1,0 +1,65 @@
+package com.wanted.teamr.tastyfinder.api.auth.domain;
+
+import com.wanted.teamr.tastyfinder.api.member.domain.Member;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Getter
+public class MemberAdapter implements UserDetails {
+
+    private final Member member;
+
+    @Builder
+    private MemberAdapter(Member member) {
+        this.member = member;
+    }
+
+    public static MemberAdapter from(Member member) {
+        return MemberAdapter.builder()
+                .member(member)
+                .build();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority(member.getRole().name()));
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return member.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/auth/dto/TokenCreateRequest.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/auth/dto/TokenCreateRequest.java
@@ -1,0 +1,18 @@
+package com.wanted.teamr.tastyfinder.api.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TokenCreateRequest {
+
+    @NotBlank
+    @Email(regexp = "^[\\w!#$%&amp;'*+/=?`{|}~^-]+(?:\\.[\\w!#$%&amp;'*+/=?`{|}~^-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}$")
+    private final String email;
+
+    @NotBlank
+    private final String password;
+}

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/auth/dto/TokenCreateResponse.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/auth/dto/TokenCreateResponse.java
@@ -1,0 +1,15 @@
+package com.wanted.teamr.tastyfinder.api.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+public class TokenCreateResponse {
+
+    private String grantType;
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/auth/infrastructure/JwtAuthenticationFilter.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/auth/infrastructure/JwtAuthenticationFilter.java
@@ -2,7 +2,7 @@ package com.wanted.teamr.tastyfinder.api.auth.infrastructure;
 
 import static com.wanted.teamr.tastyfinder.api.auth.infrastructure.JwtTokenProvider.CLAIMS_AUTH;
 import static com.wanted.teamr.tastyfinder.api.auth.infrastructure.JwtTokenProvider.GRANTTYPE_BEARER;
-import static com.wanted.teamr.tastyfinder.api.exception.ErrorCode.AUTH_JWT_TOKEN_UNPRIVILEGED;
+import static com.wanted.teamr.tastyfinder.api.exception.ErrorCode.AUTH_JWT_UNPRIVILEGED;
 
 import com.wanted.teamr.tastyfinder.api.exception.CustomException;
 import io.jsonwebtoken.Claims;
@@ -51,7 +51,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private Authentication getAuthentication(String accessToken) {
         Claims claims = jwtTokenProvider.parseClaims(accessToken);
         if (claims.get(CLAIMS_AUTH) == null) {
-            throw new CustomException(AUTH_JWT_TOKEN_UNPRIVILEGED);
+            throw new CustomException(AUTH_JWT_UNPRIVILEGED);
         }
         UserDetails userDetails = userDetailsService.loadUserByUsername(claims.getSubject());
         return new UsernamePasswordAuthenticationToken(userDetails, accessToken, userDetails.getAuthorities());

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/auth/infrastructure/JwtAuthenticationFilter.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/auth/infrastructure/JwtAuthenticationFilter.java
@@ -1,0 +1,59 @@
+package com.wanted.teamr.tastyfinder.api.auth.infrastructure;
+
+import static com.wanted.teamr.tastyfinder.api.auth.infrastructure.JwtTokenProvider.CLAIMS_AUTH;
+import static com.wanted.teamr.tastyfinder.api.auth.infrastructure.JwtTokenProvider.GRANTTYPE_BEARER;
+import static com.wanted.teamr.tastyfinder.api.exception.ErrorCode.AUTH_JWT_TOKEN_UNPRIVILEGED;
+
+import com.wanted.teamr.tastyfinder.api.exception.CustomException;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserDetailsService userDetailsService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String token = resolveToken(request);
+        if (token != null) {
+            jwtTokenProvider.validateToken(token);
+            Authentication authentication = getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(GRANTTYPE_BEARER)) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    private Authentication getAuthentication(String accessToken) {
+        Claims claims = jwtTokenProvider.parseClaims(accessToken);
+        if (claims.get(CLAIMS_AUTH) == null) {
+            throw new CustomException(AUTH_JWT_TOKEN_UNPRIVILEGED);
+        }
+        UserDetails userDetails = userDetailsService.loadUserByUsername(claims.getSubject());
+        return new UsernamePasswordAuthenticationToken(userDetails, accessToken, userDetails.getAuthorities());
+    }
+}

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/auth/infrastructure/JwtAuthenticationFilter.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/auth/infrastructure/JwtAuthenticationFilter.java
@@ -43,7 +43,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private String resolveToken(HttpServletRequest request) {
         String bearerToken = request.getHeader(HttpHeaders.AUTHORIZATION);
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(GRANTTYPE_BEARER)) {
-            return bearerToken.substring(7);
+            return bearerToken.substring(GRANTTYPE_BEARER.length() + 1);
         }
         return null;
     }

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/auth/infrastructure/JwtTokenProvider.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/auth/infrastructure/JwtTokenProvider.java
@@ -1,0 +1,96 @@
+package com.wanted.teamr.tastyfinder.api.auth.infrastructure;
+
+import static com.wanted.teamr.tastyfinder.api.exception.ErrorCode.*;
+import static io.jsonwebtoken.SignatureAlgorithm.HS256;
+
+import com.wanted.teamr.tastyfinder.api.auth.dto.TokenCreateResponse;
+import com.wanted.teamr.tastyfinder.api.exception.CustomException;
+import com.wanted.teamr.tastyfinder.api.member.domain.Member;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SecurityException;
+import java.security.Key;
+import java.util.Date;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+    public static final String CLAIMS_AUTH = "auth";
+    public static final String GRANTTYPE_BEARER = "Bearer";
+
+    private final long expirationTimeMillis;
+    private final Key key;
+
+    public JwtTokenProvider(@Value("${security.jwt.token.secret-key}") final String secretKey,
+                            @Value("${security.jwt.token.expire-period}") final Long expirationTimeMillis) {
+        byte[] secretByteKey = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(secretByteKey);
+        this.expirationTimeMillis = expirationTimeMillis;
+    }
+
+    public TokenCreateResponse generateToken(final Member member) {
+        final String accessToken = generateAccessToken(member);
+        final String refreshToken = generateRefreshToken();
+        return TokenCreateResponse.builder()
+                .grantType(GRANTTYPE_BEARER)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    public void validateToken(final String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token).getBody();
+        } catch (SecurityException | MalformedJwtException e) {
+            throw new CustomException(AUTH_JWT_TOKEN_INVALID, e);
+        } catch (ExpiredJwtException e) {
+            throw new CustomException(AUTH_JWT_TOKEN_EXPIRED, e);
+        } catch (UnsupportedJwtException e) {
+            throw new CustomException(AUTH_JWT_TOKEN_UNSUPPORTED, e);
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(AUTH_JWT_CLAIMS_EMPTY, e);
+        }
+    }
+
+    public Claims parseClaims(final String accessToken) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(accessToken)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+
+    private String generateAccessToken(final Member member) {
+        final Date expiration = new Date(System.currentTimeMillis() + expirationTimeMillis);
+        return Jwts.builder()
+                .setSubject(member.getEmail())
+                .claim(CLAIMS_AUTH, member.getRole())
+                .setExpiration(expiration)
+                .signWith(key, HS256)
+                .compact();
+    }
+
+    private String generateRefreshToken() {
+        final Date expiration = new Date(System.currentTimeMillis() + expirationTimeMillis * 24 * 7);
+        return Jwts.builder()
+                .setExpiration(expiration)
+                .signWith(key, HS256)
+                .compact();
+    }
+}

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/auth/infrastructure/JwtTokenProvider.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/auth/infrastructure/JwtTokenProvider.java
@@ -30,8 +30,8 @@ public class JwtTokenProvider {
     private final long expirationTimeMillis;
     private final Key key;
 
-    public JwtTokenProvider(@Value("${security.jwt.token.secret-key}") final String secretKey,
-                            @Value("${security.jwt.token.expire-period}") final Long expirationTimeMillis) {
+    public JwtTokenProvider(@Value("${security.jwt.secret-key}") final String secretKey,
+                            @Value("${security.jwt.expire-period}") final Long expirationTimeMillis) {
         byte[] secretByteKey = Decoders.BASE64.decode(secretKey);
         this.key = Keys.hmacShaKeyFor(secretByteKey);
         this.expirationTimeMillis = expirationTimeMillis;
@@ -54,11 +54,11 @@ public class JwtTokenProvider {
                     .build()
                     .parseClaimsJws(token).getBody();
         } catch (SecurityException | MalformedJwtException e) {
-            throw new CustomException(AUTH_JWT_TOKEN_INVALID, e);
+            throw new CustomException(AUTH_JWT_INVALID, e);
         } catch (ExpiredJwtException e) {
-            throw new CustomException(AUTH_JWT_TOKEN_EXPIRED, e);
+            throw new CustomException(AUTH_JWT_EXPIRED, e);
         } catch (UnsupportedJwtException e) {
-            throw new CustomException(AUTH_JWT_TOKEN_UNSUPPORTED, e);
+            throw new CustomException(AUTH_JWT_UNSUPPORTED, e);
         } catch (IllegalArgumentException e) {
             throw new CustomException(AUTH_JWT_CLAIMS_EMPTY, e);
         }

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/auth/service/AuthService.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/auth/service/AuthService.java
@@ -1,0 +1,32 @@
+package com.wanted.teamr.tastyfinder.api.auth.service;
+
+import com.wanted.teamr.tastyfinder.api.auth.domain.MemberAdapter;
+import com.wanted.teamr.tastyfinder.api.auth.dto.TokenCreateRequest;
+import com.wanted.teamr.tastyfinder.api.auth.dto.TokenCreateResponse;
+import com.wanted.teamr.tastyfinder.api.auth.infrastructure.JwtTokenProvider;
+import com.wanted.teamr.tastyfinder.api.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Transactional(readOnly = true)
+    public TokenCreateResponse login(TokenCreateRequest tokenCreateRequest) {
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
+                tokenCreateRequest.getEmail(),
+                tokenCreateRequest.getPassword()
+        );
+        Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+        Member member = ((MemberAdapter) authentication.getPrincipal()).getMember();
+        return jwtTokenProvider.generateToken(member);
+    }
+}

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/auth/service/UserDetailsServiceImpl.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/auth/service/UserDetailsServiceImpl.java
@@ -1,0 +1,27 @@
+package com.wanted.teamr.tastyfinder.api.auth.service;
+
+import static com.wanted.teamr.tastyfinder.api.exception.ErrorCode.MEMBER_NOT_EXISTS;
+
+import com.wanted.teamr.tastyfinder.api.auth.domain.MemberAdapter;
+import com.wanted.teamr.tastyfinder.api.exception.CustomException;
+import com.wanted.teamr.tastyfinder.api.member.domain.Member;
+import com.wanted.teamr.tastyfinder.api.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(MEMBER_NOT_EXISTS));
+        return MemberAdapter.from(member);
+    }
+}

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/config/SecurityConfig.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/config/SecurityConfig.java
@@ -1,8 +1,9 @@
 package com.wanted.teamr.tastyfinder.api.config;
 
 import static org.springframework.boot.autoconfigure.security.servlet.PathRequest.toH2Console;
-import static org.springframework.security.config.Customizer.withDefaults;
 
+import com.wanted.teamr.tastyfinder.api.auth.infrastructure.JwtAuthenticationFilter;
+import com.wanted.teamr.tastyfinder.api.auth.infrastructure.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,15 +13,20 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserDetailsService userDetailsService;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -40,6 +46,7 @@ public class SecurityConfig {
                         .disable()
                 )
                 .formLogin(AbstractHttpConfigurer::disable)
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, userDetailsService), UsernamePasswordAuthenticationFilter.class)
                 .sessionManagement(sessionManager -> sessionManager.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
         return http.build();
     }

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/exception/CustomErrorResponse.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/exception/CustomErrorResponse.java
@@ -1,0 +1,15 @@
+package com.wanted.teamr.tastyfinder.api.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomErrorResponse {
+
+    private final String errorCode;
+    private final String message;
+
+    public CustomErrorResponse(ErrorCodeType errorCodeType) {
+        errorCode = errorCodeType.name();
+        message = errorCodeType.getMessage();
+    }
+}

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/exception/CustomException.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/exception/CustomException.java
@@ -1,0 +1,19 @@
+package com.wanted.teamr.tastyfinder.api.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final ErrorCodeType errorCodeType;
+
+    public CustomException(ErrorCodeType errorCodeType) {
+        super(errorCodeType.getMessage());
+        this.errorCodeType = errorCodeType;
+    }
+
+    public CustomException(ErrorCodeType errorCodeType, Throwable cause) {
+        super(errorCodeType.getMessage(), cause);
+        this.errorCodeType = errorCodeType;
+    }
+}

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/exception/ErrorCode.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/exception/ErrorCode.java
@@ -1,0 +1,24 @@
+package com.wanted.teamr.tastyfinder.api.exception;
+
+import static org.springframework.http.HttpStatus.*;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum ErrorCode implements ErrorCodeType {
+
+    AUTH_JWT_TOKEN_INVALID("Invalid JWT Token", FORBIDDEN),
+    AUTH_JWT_TOKEN_EXPIRED("Expired JWT Token", FORBIDDEN),
+    AUTH_JWT_CLAIMS_EMPTY("JWT claims string is empty.", FORBIDDEN),
+    AUTH_JWT_TOKEN_UNPRIVILEGED("Unprivileged JWT Token", FORBIDDEN),
+    AUTH_JWT_TOKEN_UNSUPPORTED("Unsupported JWT Token", FORBIDDEN),
+
+    MEMBER_NOT_EXISTS("존재하지 않는 사용자입니다.", FORBIDDEN)
+    ;
+
+    private final String message;
+    private final HttpStatus httpStatus;
+}

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/exception/ErrorCode.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/exception/ErrorCode.java
@@ -10,11 +10,11 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode implements ErrorCodeType {
 
-    AUTH_JWT_TOKEN_INVALID("Invalid JWT Token", FORBIDDEN),
-    AUTH_JWT_TOKEN_EXPIRED("Expired JWT Token", FORBIDDEN),
     AUTH_JWT_CLAIMS_EMPTY("JWT claims string is empty.", FORBIDDEN),
-    AUTH_JWT_TOKEN_UNPRIVILEGED("Unprivileged JWT Token", FORBIDDEN),
-    AUTH_JWT_TOKEN_UNSUPPORTED("Unsupported JWT Token", FORBIDDEN),
+    AUTH_JWT_EXPIRED("Expired JWT Token", FORBIDDEN),
+    AUTH_JWT_INVALID("Invalid JWT Token", FORBIDDEN),
+    AUTH_JWT_UNPRIVILEGED("Unprivileged JWT Token", FORBIDDEN),
+    AUTH_JWT_UNSUPPORTED("Unsupported JWT Token", FORBIDDEN),
 
     MEMBER_NOT_EXISTS("존재하지 않는 사용자입니다.", FORBIDDEN)
     ;

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/exception/ErrorCodeType.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/exception/ErrorCodeType.java
@@ -1,0 +1,10 @@
+package com.wanted.teamr.tastyfinder.api.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCodeType {
+
+    String name();
+    String getMessage();
+    HttpStatus getHttpStatus();
+}

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/exception/GlobalExceptionHandler.java
@@ -1,0 +1,32 @@
+package com.wanted.teamr.tastyfinder.api.exception;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.web.servlet.server.Encoding;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<?> handleCustomException(CustomException e) {
+        log.error("CustomException", e);
+        ErrorCodeType errorCodeType = e.getErrorCodeType();
+        CustomErrorResponse customErrorResponse = new CustomErrorResponse(errorCodeType);
+        return makeResponseEntity(errorCodeType.getHttpStatus(), customErrorResponse);
+    }
+
+    private ResponseEntity<?> makeResponseEntity(HttpStatus httpStatus, CustomErrorResponse customErrorResponse) {
+        return ResponseEntity.status(httpStatus)
+                .header(HttpHeaders.CONTENT_ENCODING, Encoding.DEFAULT_CHARSET.name())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(customErrorResponse);
+    }
+}

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/member/domain/Member.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/member/domain/Member.java
@@ -1,14 +1,19 @@
 package com.wanted.teamr.tastyfinder.api.member.domain;
 
+import static com.wanted.teamr.tastyfinder.api.member.domain.Role.ROLE_USER;
+
 import com.wanted.teamr.tastyfinder.api.member.dto.MemberCreateRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.validation.constraints.Email;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Getter
 @Entity
@@ -30,24 +35,30 @@ public class Member {
     private Float longitude; //경도
 
     @Column(nullable = false)
-    private boolean isRecommendEnabled = false;
+    private boolean isRecommendEnabled;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    private Role role;
 
     protected Member() {
     }
 
     @Builder
-    private Member(String email, String password, Float latitude, Float longitude, Boolean isRecommendEnabled) {
+    private Member(String email, String password, Float latitude, Float longitude, Boolean isRecommendEnabled, Role role) {
         this.email = email;
         this.password = password;
         this.latitude = latitude;
         this.longitude = longitude;
-        this.isRecommendEnabled = isRecommendEnabled != null ? isRecommendEnabled : false;
+        this.isRecommendEnabled = (isRecommendEnabled != null) ? isRecommendEnabled : false;
+        this.role = (role != null) ? role : ROLE_USER;
     }
 
-    public static Member from(MemberCreateRequest memberCreateRequest) {
+    public static Member of(MemberCreateRequest memberCreateRequest, PasswordEncoder passwordEncoder) {
+        String encodePassword = passwordEncoder.encode(memberCreateRequest.getPassword());
         return Member.builder()
                 .email(memberCreateRequest.getEmail())
-                .password(memberCreateRequest.getPassword())
+                .password(encodePassword)
                 .build();
     }
 }

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/member/domain/Role.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/member/domain/Role.java
@@ -1,0 +1,6 @@
+package com.wanted.teamr.tastyfinder.api.member.domain;
+
+public enum Role {
+    ROLE_USER,
+    ROLE_ADMIN
+}

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/member/repository/MemberRepository.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/member/repository/MemberRepository.java
@@ -1,7 +1,10 @@
 package com.wanted.teamr.tastyfinder.api.member.repository;
 
 import com.wanted.teamr.tastyfinder.api.member.domain.Member;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/member/service/MemberService.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/member/service/MemberService.java
@@ -4,6 +4,7 @@ import com.wanted.teamr.tastyfinder.api.member.domain.Member;
 import com.wanted.teamr.tastyfinder.api.member.dto.MemberCreateRequest;
 import com.wanted.teamr.tastyfinder.api.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,10 +13,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Transactional
     public Long createMember(MemberCreateRequest memberCreateRequest) {
-        Member member = Member.from(memberCreateRequest);
+        Member member = Member.of(memberCreateRequest, passwordEncoder);
         return memberRepository.save(member).getId();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,5 +28,5 @@ logging:
 
 security:
   jwt:
-    secret-key: c3ByaW5nLWJvb3Qtc2VjdXJpdHktand0LXdhbnRlZC1wcmUtb25ib2FyZGluZy1iYWNrZW5kLWludGVybnNoaXAtc3ByaW5nLWJvb3Qtc2VjdXJpdHktand0LXNlY3JldC1rZXkK
+    secret-key:
     expire-period: 3600000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,5 +26,8 @@ logging:
   level:
     sql: trace
 
-#jwt:
-#  secret: {jwt_key}
+security:
+  jwt:
+    token:
+      secret-key: c3ByaW5nLWJvb3Qtc2VjdXJpdHktand0LXdhbnRlZC1wcmUtb25ib2FyZGluZy1iYWNrZW5kLWludGVybnNoaXAtc3ByaW5nLWJvb3Qtc2VjdXJpdHktand0LXNlY3JldC1rZXkK
+      expire-period: 3600000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,6 +28,5 @@ logging:
 
 security:
   jwt:
-    token:
-      secret-key: c3ByaW5nLWJvb3Qtc2VjdXJpdHktand0LXdhbnRlZC1wcmUtb25ib2FyZGluZy1iYWNrZW5kLWludGVybnNoaXAtc3ByaW5nLWJvb3Qtc2VjdXJpdHktand0LXNlY3JldC1rZXkK
-      expire-period: 3600000
+    secret-key: c3ByaW5nLWJvb3Qtc2VjdXJpdHktand0LXdhbnRlZC1wcmUtb25ib2FyZGluZy1iYWNrZW5kLWludGVybnNoaXAtc3ByaW5nLWJvb3Qtc2VjdXJpdHktand0LXNlY3JldC1rZXkK
+    expire-period: 3600000

--- a/src/test/java/com/wanted/teamr/tastyfinder/api/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/wanted/teamr/tastyfinder/api/auth/controller/AuthControllerTest.java
@@ -1,0 +1,135 @@
+package com.wanted.teamr.tastyfinder.api.auth.controller;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wanted.teamr.tastyfinder.api.auth.dto.TokenCreateRequest;
+import com.wanted.teamr.tastyfinder.api.member.domain.Member;
+import com.wanted.teamr.tastyfinder.api.member.dto.MemberCreateRequest;
+import com.wanted.teamr.tastyfinder.api.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+class AuthControllerTest {
+
+    private final String email = "test@test.com";
+    private final String password = "12345678";
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @BeforeEach
+    void setUp() {
+        MemberCreateRequest memberCreateRequest = MemberCreateRequest.builder()
+                .email(email)
+                .password(password)
+                .build();
+        memberRepository.save(Member.of(memberCreateRequest, passwordEncoder));
+    }
+
+    @Test
+    @DisplayName("로그인 요청 시 jwt를 발급받는다.")
+    void login() throws Exception {
+        //given
+        TokenCreateRequest tokenCreateRequest = TokenCreateRequest.builder()
+                .email(email)
+                .password(password)
+                .build();
+
+        //when then
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(tokenCreateRequest)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.grantType").value("Bearer"))
+                .andExpect(jsonPath("$.accessToken").exists())
+                .andExpect(jsonPath("$.refreshToken").exists());
+    }
+
+    @Test
+    @DisplayName("잘못된 이메일로 로그인할 수 없다.")
+    void login_invalidEmail() throws Exception {
+        //given
+        TokenCreateRequest tokenCreateRequest = TokenCreateRequest.builder()
+                .email(email + "t")
+                .password(password)
+                .build();
+
+        //when then
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(tokenCreateRequest)))
+                .andDo(print())
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("잘못된 비밀번호로 로그인할 수 없다.")
+    void login_invalidPassword() throws Exception {
+        //given
+        TokenCreateRequest tokenCreateRequest = TokenCreateRequest.builder()
+                .email(email)
+                .password(password + "t")
+                .build();
+
+        //when then
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(tokenCreateRequest)))
+                .andDo(print())
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("이메일 없이 로그인할 수 없다.")
+    void login_emptyEmail() throws Exception {
+        //given
+        TokenCreateRequest tokenCreateRequest = TokenCreateRequest.builder()
+                .password(password)
+                .build();
+
+        //when then
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(tokenCreateRequest)))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("비밀번호 없이 로그인할 수 없다.")
+    void login_emptyPassword() throws Exception {
+        //given
+        TokenCreateRequest tokenCreateRequest = TokenCreateRequest.builder()
+                .email(email)
+                .build();
+
+        //when then
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(tokenCreateRequest)))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/wanted/teamr/tastyfinder/api/auth/infrastructure/JwtTokenProviderTest.java
+++ b/src/test/java/com/wanted/teamr/tastyfinder/api/auth/infrastructure/JwtTokenProviderTest.java
@@ -1,0 +1,87 @@
+package com.wanted.teamr.tastyfinder.api.auth.infrastructure;
+
+import static com.wanted.teamr.tastyfinder.api.exception.ErrorCode.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.wanted.teamr.tastyfinder.api.auth.dto.TokenCreateResponse;
+import com.wanted.teamr.tastyfinder.api.exception.CustomException;
+import com.wanted.teamr.tastyfinder.api.member.domain.Member;
+import com.wanted.teamr.tastyfinder.api.member.dto.MemberCreateRequest;
+import com.wanted.teamr.tastyfinder.api.member.repository.MemberRepository;
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+class JwtTokenProviderTest {
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        MemberCreateRequest memberCreateRequest = MemberCreateRequest.builder()
+                .email("test@test.com")
+                .password("12345678")
+                .build();
+        member = memberRepository.save(Member.of(memberCreateRequest, passwordEncoder));
+    }
+
+    @Test
+    @DisplayName("JWT를 생성할 수 있다.")
+    void generateToken() {
+        //when
+        TokenCreateResponse tokenCreateResponse = jwtTokenProvider.generateToken(member);
+
+        //then
+        assertThat(tokenCreateResponse).isNotNull();
+    }
+
+    @Test
+    @DisplayName("accessToken의 유효기간을 검증할 수 있다.")
+    void validateToken_accessToken() throws NoSuchFieldException, IllegalAccessException {
+        //given
+        setExpirationTimeMillis(-100000L);
+        TokenCreateResponse tokenCreateResponse = jwtTokenProvider.generateToken(member);
+
+        //when
+        assertThatThrownBy(() -> jwtTokenProvider.validateToken(tokenCreateResponse.getAccessToken()))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(AUTH_JWT_TOKEN_EXPIRED.getMessage());
+    }
+
+    @Test
+    @DisplayName("refreshToken의 유효기간을 검증할 수 있다.")
+    void validateToken_refreshToken() throws NoSuchFieldException, IllegalAccessException {
+        //given
+        setExpirationTimeMillis(-10000L);
+        TokenCreateResponse tokenCreateResponse = jwtTokenProvider.generateToken(member);
+
+        //when
+        assertThatThrownBy(() -> jwtTokenProvider.validateToken(tokenCreateResponse.getRefreshToken()))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(AUTH_JWT_TOKEN_EXPIRED.getMessage());
+    }
+
+    /**
+     * 리플렉션을 사용하여 JwtTokenProvider.expirationTimeMillis 변경
+     */
+    private void setExpirationTimeMillis(Long expirationTimeMillis) throws NoSuchFieldException, IllegalAccessException {
+        Field field = JwtTokenProvider.class.getDeclaredField("expirationTimeMillis");
+        field.setAccessible(true);
+        field.set(jwtTokenProvider, expirationTimeMillis);
+    }
+}

--- a/src/test/java/com/wanted/teamr/tastyfinder/api/auth/infrastructure/JwtTokenProviderTest.java
+++ b/src/test/java/com/wanted/teamr/tastyfinder/api/auth/infrastructure/JwtTokenProviderTest.java
@@ -60,7 +60,7 @@ class JwtTokenProviderTest {
         //when
         assertThatThrownBy(() -> jwtTokenProvider.validateToken(tokenCreateResponse.getAccessToken()))
                 .isInstanceOf(CustomException.class)
-                .hasMessage(AUTH_JWT_TOKEN_EXPIRED.getMessage());
+                .hasMessage(AUTH_JWT_EXPIRED.getMessage());
     }
 
     @Test
@@ -73,7 +73,7 @@ class JwtTokenProviderTest {
         //when
         assertThatThrownBy(() -> jwtTokenProvider.validateToken(tokenCreateResponse.getRefreshToken()))
                 .isInstanceOf(CustomException.class)
-                .hasMessage(AUTH_JWT_TOKEN_EXPIRED.getMessage());
+                .hasMessage(AUTH_JWT_EXPIRED.getMessage());
     }
 
     /**

--- a/src/test/java/com/wanted/teamr/tastyfinder/api/auth/service/AuthServiceMockTest.java
+++ b/src/test/java/com/wanted/teamr/tastyfinder/api/auth/service/AuthServiceMockTest.java
@@ -1,0 +1,66 @@
+package com.wanted.teamr.tastyfinder.api.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.wanted.teamr.tastyfinder.api.auth.domain.MemberAdapter;
+import com.wanted.teamr.tastyfinder.api.auth.dto.TokenCreateRequest;
+import com.wanted.teamr.tastyfinder.api.auth.dto.TokenCreateResponse;
+import com.wanted.teamr.tastyfinder.api.auth.infrastructure.JwtTokenProvider;
+import com.wanted.teamr.tastyfinder.api.member.domain.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceMockTest {
+
+    @InjectMocks
+    private AuthService authService;
+    @Mock
+    private AuthenticationManagerBuilder authenticationManagerBuilder;
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+    @Mock
+    private AuthenticationManager authenticationManager;
+    @Mock
+    private Authentication authentication;
+
+    @Test
+    @DisplayName("로그인 할 수 있다")
+    void login() {
+        //given
+        TokenCreateRequest tokenCreateRequest = TokenCreateRequest.builder()
+                .email("test@example.com")
+                .password("password")
+                .build();
+        TokenCreateResponse expectedResponse = TokenCreateResponse.builder()
+                .grantType("Bearer")
+                .accessToken("TOKEN")
+                .refreshToken("TOKEN")
+                .build();
+        Member member = Member.builder()
+                .email("test@example.com")
+                .password("password")
+                .build();
+        given(authenticationManagerBuilder.getObject()).willReturn(authenticationManager);
+        given(authenticationManager.authenticate(any())).willReturn(authentication);
+        given(jwtTokenProvider.generateToken(any())).willReturn(expectedResponse);
+        given(authentication.getPrincipal()).willReturn(MemberAdapter.from(member));
+
+        //when
+        TokenCreateResponse actualResponse = authService.login(tokenCreateRequest);
+
+        //then
+        assertThat(actualResponse.getGrantType()).isEqualTo(expectedResponse.getGrantType());
+        assertThat(actualResponse.getAccessToken()).isEqualTo(expectedResponse.getAccessToken());
+        assertThat(actualResponse.getRefreshToken()).isEqualTo(expectedResponse.getRefreshToken());
+    }
+}

--- a/src/test/java/com/wanted/teamr/tastyfinder/api/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/wanted/teamr/tastyfinder/api/member/controller/MemberControllerTest.java
@@ -67,7 +67,6 @@ class MemberControllerTest {
                         .content(objectMapper.writeValueAsString(memberCreateRequest))
                 )
                 .andDo(print())
-                //TODO: exception 처리 수정
                 .andExpect(status().isBadRequest());
     }
 
@@ -87,7 +86,6 @@ class MemberControllerTest {
                         .content(objectMapper.writeValueAsString(memberCreateRequest))
                 )
                 .andDo(print())
-                //TODO: exception 처리 수정
                 .andExpect(status().isBadRequest());
     }
 
@@ -107,7 +105,6 @@ class MemberControllerTest {
                         .content(objectMapper.writeValueAsString(memberCreateRequest))
                 )
                 .andDo(print())
-                //TODO: exception 처리 수정
                 .andExpect(status().isBadRequest());
     }
 }

--- a/src/test/java/com/wanted/teamr/tastyfinder/api/member/service/MemberServiceTest.java
+++ b/src/test/java/com/wanted/teamr/tastyfinder/api/member/service/MemberServiceTest.java
@@ -1,17 +1,16 @@
 package com.wanted.teamr.tastyfinder.api.member.service;
 
+import static com.wanted.teamr.tastyfinder.api.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.wanted.teamr.tastyfinder.api.exception.CustomException;
 import com.wanted.teamr.tastyfinder.api.member.domain.Member;
 import com.wanted.teamr.tastyfinder.api.member.dto.MemberCreateRequest;
 import com.wanted.teamr.tastyfinder.api.member.repository.MemberRepository;
-import jakarta.validation.ConstraintViolationException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
@@ -44,52 +43,8 @@ class MemberServiceTest {
         assertThat(findedMember.getEmail()).isEqualTo(memberCreateRequest.getEmail());
     }
 
-    @Test
-    @DisplayName("잘못된 이메일로 사용자를 생성할 수 없다.")
-    void createMember_invalidEmail() {
-        //given
-        MemberCreateRequest memberCreateRequest = MemberCreateRequest.builder()
-                .email("invalidTest.com")
-                .password(testPassword)
-                .build();
-
-        //when then
-        assertThatThrownBy(() -> memberService.createMember(memberCreateRequest))
-                //TODO: exception 처리 수정
-                .isInstanceOf(ConstraintViolationException.class);
-    }
-
-    @Test
-    @DisplayName("이메일 없이 사용자를 생성할 수 없다.")
-    void createMember_emptyEmail() {
-        //given
-        MemberCreateRequest memberCreateRequest = MemberCreateRequest.builder()
-                .password(testPassword)
-                .build();
-
-        //when then
-        assertThatThrownBy(() -> memberService.createMember(memberCreateRequest))
-                //TODO: exception 처리 수정
-                .isInstanceOf(DataIntegrityViolationException.class);
-    }
-
-    @Test
-    @DisplayName("비밀번호 없이 사용자를 생성할 수 없다.")
-    void createMember_emptyPassword() {
-        //given
-        MemberCreateRequest memberCreateRequest = MemberCreateRequest.builder()
-                .email(testEmail)
-                .build();
-
-        //when then
-        assertThatThrownBy(() -> memberService.createMember(memberCreateRequest))
-                //TODO: exception 처리 수정
-                .isInstanceOf(DataIntegrityViolationException.class);
-    }
-
     private Member findMemberById(Long memberId) {
         return memberRepository.findById(memberId)
-                //TODO: exception 처리 수정
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+                .orElseThrow(() -> new CustomException(MEMBER_NOT_EXISTS));
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -15,3 +15,9 @@ spring:
 
 #jwt:
 #  secret: {jwt_key}
+
+security:
+  jwt:
+    token:
+      secret-key: c3ByaW5nLWJvb3Qtc2VjdXJpdHktand0LXdhbnRlZC1wcmUtb25ib2FyZGluZy1iYWNrZW5kLWludGVybnNoaXAtc3ByaW5nLWJvb3Qtc2VjdXJpdHktand0LXNlY3JldC1rZXkK
+      expire-period: 3600000

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -18,5 +18,5 @@ spring:
 
 security:
   jwt:
-    secret-key: c3ByaW5nLWJvb3Qtc2VjdXJpdHktand0LXdhbnRlZC1wcmUtb25ib2FyZGluZy1iYWNrZW5kLWludGVybnNoaXAtc3ByaW5nLWJvb3Qtc2VjdXJpdHktand0LXNlY3JldC1rZXkK
+    secret-key:
     expire-period: 3600000

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -18,6 +18,5 @@ spring:
 
 security:
   jwt:
-    token:
-      secret-key: c3ByaW5nLWJvb3Qtc2VjdXJpdHktand0LXdhbnRlZC1wcmUtb25ib2FyZGluZy1iYWNrZW5kLWludGVybnNoaXAtc3ByaW5nLWJvb3Qtc2VjdXJpdHktand0LXNlY3JldC1rZXkK
-      expire-period: 3600000
+    secret-key: c3ByaW5nLWJvb3Qtc2VjdXJpdHktand0LXdhbnRlZC1wcmUtb25ib2FyZGluZy1iYWNrZW5kLWludGVybnNoaXAtc3ByaW5nLWJvb3Qtc2VjdXJpdHktand0LXNlY3JldC1rZXkK
+    expire-period: 3600000


### PR DESCRIPTION
## 📃 설명

- resolves #2 
- 사용자 로그인 요청 시 JWT를 발급하는 API 추가한다.

## 🔨 작업 내용

- 사용자 로그인 요청 API 구현
  - JWT 발급: grantType, accessToken, refreshToken
- 공통 exception 처리 로직 추가

## 💬 기타 사항

- 타 API에서 로그인한 사용자의 정보를 사용하는 경우가 있어서 빠른 merge를 위해 PR 올림.
  - exception 처리 등 수정이 필요한 부분은 다른 이슈를 생성하여 처리 예정.
- UserDetails 구현체: `MemberAdapter.java`