### PR TITLE
feat #7: 맛집 상세정보 API 구현

### DIFF
--- a/src/main/java/com/wanted/teamr/tastyfinder/TastyFinderApplication.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/TastyFinderApplication.java
@@ -2,8 +2,10 @@ package com.wanted.teamr.tastyfinder;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class TastyFinderApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/common/BaseEntity.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/common/BaseEntity.java
@@ -1,0 +1,23 @@
+package com.wanted.teamr.tastyfinder.api.common;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+
+}

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/common/BaseTimeEntity.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/common/BaseTimeEntity.java
@@ -12,12 +12,12 @@ import java.time.LocalDateTime;
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-public abstract class BaseEntity {
+public abstract class BaseTimeEntity {
 
     @CreatedDate
     private LocalDateTime createdAt;
 
     @LastModifiedDate
-    private LocalDateTime modifiedAt;
+    private LocalDateTime updatedAt;
 
 }

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/exception/ErrorCode.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/exception/ErrorCode.java
@@ -15,8 +15,12 @@ public enum ErrorCode implements ErrorCodeType {
     AUTH_JWT_INVALID("Invalid JWT Token", FORBIDDEN),
     AUTH_JWT_UNPRIVILEGED("Unprivileged JWT Token", FORBIDDEN),
     AUTH_JWT_UNSUPPORTED("Unsupported JWT Token", FORBIDDEN),
+    MEMBER_NOT_EXISTS("존재하지 않는 사용자입니다.", FORBIDDEN),
 
-    MEMBER_NOT_EXISTS("존재하지 않는 사용자입니다.", FORBIDDEN)
+    MATZIP_NOT_FOUND("맛집 게시물이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    INPUT_VALUE_INVALID("입력 값이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
+
+
     ;
 
     private final String message;

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/matzip/controller/MatzipController.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/matzip/controller/MatzipController.java
@@ -1,0 +1,22 @@
+package com.wanted.teamr.tastyfinder.api.matzip.controller;
+
+import com.wanted.teamr.tastyfinder.api.matzip.dto.MatzipResponse;
+import com.wanted.teamr.tastyfinder.api.matzip.service.MatzipService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class MatzipController {
+    private final MatzipService matzipService;
+
+    @GetMapping("/api/matzips/{matzipId}")
+    public ResponseEntity<MatzipResponse> getMatzip(@PathVariable("matzipId") Long matzipId) {
+        MatzipResponse matzipResponse = matzipService.getMatzip(matzipId);
+        return ResponseEntity.ok(matzipResponse);
+    }
+
+}

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/matzip/domain/Matzip.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/matzip/domain/Matzip.java
@@ -1,0 +1,45 @@
+package com.wanted.teamr.tastyfinder.api.matzip.domain;
+
+import com.wanted.teamr.tastyfinder.api.review.domain.Review;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Matzip {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long Id;
+
+    @Column(nullable = false)
+    private int totalRating = 0;
+
+    @Column(nullable = false)
+    private int reviewCount = 0;
+
+    @OneToMany(mappedBy = "matzip", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
+    private List<Review> reviews = new ArrayList<>();
+
+    public void updateTotalRating(Review review) {
+        totalRating += review.getRating();
+    }
+
+    public void updateReviewCount() {
+        reviewCount += 1;
+    }
+
+    @Builder
+    public Matzip(int totalRating, int reviewCount, List<Review> reviews) {
+        this.totalRating = totalRating;
+        this.reviewCount = reviewCount;
+        this.reviews = reviews;
+    }
+
+}

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/matzip/dto/MatzipResponse.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/matzip/dto/MatzipResponse.java
@@ -1,0 +1,30 @@
+package com.wanted.teamr.tastyfinder.api.matzip.dto;
+
+import com.wanted.teamr.tastyfinder.api.matzip.domain.Matzip;
+import com.wanted.teamr.tastyfinder.api.review.dto.ReviewResponse;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class MatzipResponse {
+    private final Long matzipId;
+    private final int avgRating;
+    private final List<ReviewResponse> reviewList;
+
+    @Builder
+    public MatzipResponse(Long matzipId, int avgRating, List<ReviewResponse> reviewList) {
+        this.matzipId = matzipId;
+        this.avgRating = avgRating;
+        this.reviewList = reviewList;
+    }
+
+    public static MatzipResponse of(Matzip matzip, int avgRating, List<ReviewResponse> reviewList) {
+        return builder()
+                .matzipId(matzip.getId())
+                .avgRating(avgRating)
+                .reviewList(reviewList).build();
+    }
+
+}

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/matzip/repository/MatzipRepository.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/matzip/repository/MatzipRepository.java
@@ -1,0 +1,16 @@
+package com.wanted.teamr.tastyfinder.api.matzip.repository;
+
+import com.wanted.teamr.tastyfinder.api.matzip.domain.Matzip;
+import com.wanted.teamr.tastyfinder.api.review.domain.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface MatzipRepository extends JpaRepository<Matzip, Long> {
+
+    @Query("SELECT r FROM Review r WHERE r.matzip.Id = :matzipId ORDER BY r.modifiedAt DESC")
+    List<Review> findReviewByMatzipIdOrderByModifiedAtDesc(@Param("matzipId") Long matzipId);
+
+}

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/matzip/service/MatzipService.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/matzip/service/MatzipService.java
@@ -1,0 +1,48 @@
+package com.wanted.teamr.tastyfinder.api.matzip.service;
+
+import com.wanted.teamr.tastyfinder.api.exception.CustomException;
+import com.wanted.teamr.tastyfinder.api.exception.ErrorCode;
+import com.wanted.teamr.tastyfinder.api.matzip.domain.Matzip;
+import com.wanted.teamr.tastyfinder.api.matzip.dto.MatzipResponse;
+import com.wanted.teamr.tastyfinder.api.matzip.repository.MatzipRepository;
+import com.wanted.teamr.tastyfinder.api.review.domain.Review;
+import com.wanted.teamr.tastyfinder.api.review.dto.ReviewResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MatzipService {
+
+    private final MatzipRepository matzipRepository;
+
+    public MatzipResponse getMatzip(Long matzipId) {
+        Matzip matzip = isPresentMatzip(matzipId);
+        int avgRating = calculateAvgRating(matzip);
+        List<ReviewResponse> responseList = getReviewResponseList(matzip);
+        return MatzipResponse.of(matzip, avgRating, responseList);
+    }
+
+    public Matzip isPresentMatzip(Long matzipId) {
+        return matzipRepository.findById(matzipId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MATZIP_NOT_FOUND));
+    }
+
+    public int calculateAvgRating(Matzip matzip) {
+        return matzip.getTotalRating() / matzip.getReviewCount();
+    }
+
+    public List<ReviewResponse> getReviewResponseList(Matzip matzip) {
+        List<Review> reviewList = matzipRepository.findReviewByMatzipIdOrderByModifiedAtDesc(matzip.getId());
+        List<ReviewResponse> responseList = new ArrayList<>();
+        for(Review review : reviewList) {
+            ReviewResponse reviewResponse = ReviewResponse.of(review);
+            responseList.add(reviewResponse);
+        }
+        return responseList;
+    }
+
+}

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/matzip/service/MatzipService.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/matzip/service/MatzipService.java
@@ -9,6 +9,7 @@ import com.wanted.teamr.tastyfinder.api.review.domain.Review;
 import com.wanted.teamr.tastyfinder.api.review.dto.ReviewResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,14 +20,15 @@ public class MatzipService {
 
     private final MatzipRepository matzipRepository;
 
+    @Transactional(readOnly = true)
     public MatzipResponse getMatzip(Long matzipId) {
-        Matzip matzip = isPresentMatzip(matzipId);
+        Matzip matzip = getMatzipIfPresent(matzipId);
         int avgRating = calculateAvgRating(matzip);
         List<ReviewResponse> responseList = getReviewResponseList(matzip);
         return MatzipResponse.of(matzip, avgRating, responseList);
     }
 
-    public Matzip isPresentMatzip(Long matzipId) {
+    public Matzip getMatzipIfPresent(Long matzipId) {
         return matzipRepository.findById(matzipId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MATZIP_NOT_FOUND));
     }

--- a/src/test/java/com/wanted/teamr/tastyfinder/api/matzip/controller/MatzipContollerTest.java
+++ b/src/test/java/com/wanted/teamr/tastyfinder/api/matzip/controller/MatzipContollerTest.java
@@ -46,7 +46,7 @@ public class MatzipContollerTest {
     @Nested
     class GetMatzip {
 
-        @DisplayName("맛집 조회 시 맛집 상세 정보 응답을 보낸다.")
+        @DisplayName("맛집 조회 시 맛집 상세 정보 응답을 보낸다 - 평가 수정 시간 내림차순으로 정렬된다. ")
         @WithMockUser
         @Test
         void getMatzipFound() throws Exception {
@@ -78,8 +78,8 @@ public class MatzipContollerTest {
                     .andExpect(jsonPath("$.avgRating").value(3))
                     .andExpect(jsonPath("$.reviewList", hasSize(2)))
                     .andExpect(jsonPath("$.reviewList").isArray())
-                    .andExpect(jsonPath("$.reviewList[0].reviewId").value(review1.getId()))
-                    .andExpect(jsonPath("$.reviewList[1].reviewId").value(review2.getId()));
+                    .andExpect(jsonPath("$.reviewList[0].reviewId").value(review2.getId()))
+                    .andExpect(jsonPath("$.reviewList[1].reviewId").value(review1.getId()));
         }
 
         @DisplayName("맛집을 찾을 수 없을 때 에러 응답을 보낸다.")

--- a/src/test/java/com/wanted/teamr/tastyfinder/api/matzip/controller/MatzipContollerTest.java
+++ b/src/test/java/com/wanted/teamr/tastyfinder/api/matzip/controller/MatzipContollerTest.java
@@ -1,0 +1,104 @@
+package com.wanted.teamr.tastyfinder.api.matzip.controller;
+
+import com.wanted.teamr.tastyfinder.api.exception.ErrorCode;
+import com.wanted.teamr.tastyfinder.api.matzip.domain.Matzip;
+import com.wanted.teamr.tastyfinder.api.matzip.repository.MatzipRepository;
+import com.wanted.teamr.tastyfinder.api.review.domain.Review;
+import com.wanted.teamr.tastyfinder.api.review.repository.ReviewRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@DisplayName("/api/matzips 통합 테스트")
+public class MatzipContollerTest {
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    MatzipRepository matzipRepository;
+
+    @Autowired
+    ReviewRepository reviewRepository;
+
+    @BeforeEach
+    void setup() {
+        matzipRepository.deleteAll();
+    }
+
+    @DisplayName("맛집 상세 정보 API")
+    @Nested
+    class GetMatzip {
+
+        @DisplayName("맛집 조회 시 맛집 상세 정보 응답을 보낸다.")
+        @WithMockUser
+        @Test
+        void getMatzipFound() throws Exception {
+            // given
+            Matzip matzip = Matzip.builder()
+                    .totalRating(6)
+                    .reviewCount(2).build();
+            matzipRepository.save(matzip);
+
+            Review review1 = Review.builder()
+                    .matzip(matzip)
+                    .rating(4)
+                    .content("맛있어요").build();
+            Review review2 = Review.builder()
+                    .matzip(matzip)
+                    .rating(2)
+                    .content("맛없어요").build();
+            reviewRepository.save(review1);
+            reviewRepository.save(review2);
+
+            Long matzipId = matzip.getId();
+
+            // when, then
+            mockMvc.perform(get("/api/matzips/{matzipId}", matzipId))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.matzipId").value(1))
+                    .andExpect(jsonPath("$.avgRating").value(3))
+                    .andExpect(jsonPath("$.reviewList", hasSize(2)))
+                    .andExpect(jsonPath("$.reviewList").isArray())
+                    .andExpect(jsonPath("$.reviewList[0].reviewId").value(review1.getId()))
+                    .andExpect(jsonPath("$.reviewList[1].reviewId").value(review2.getId()));
+        }
+
+        @DisplayName("맛집을 찾을 수 없을 때 에러 응답을 보낸다.")
+        @WithMockUser
+        @Test
+        void getPostNotFound() throws Exception {
+            // given
+            List<Matzip> all = matzipRepository.findAll();
+            Assertions.assertThat(all).hasSize(0);
+
+            // when, then
+            mockMvc.perform(get("/api/matzips/{matzipId}", 1L))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorCode").value(ErrorCode.MATZIP_NOT_FOUND.name()))
+                    .andExpect(jsonPath("$.message").value(ErrorCode.MATZIP_NOT_FOUND.getMessage()));
+        }
+
+    }
+
+}

--- a/src/test/java/com/wanted/teamr/tastyfinder/api/matzip/controller/MatzipControllerMockTest.java
+++ b/src/test/java/com/wanted/teamr/tastyfinder/api/matzip/controller/MatzipControllerMockTest.java
@@ -1,0 +1,95 @@
+package com.wanted.teamr.tastyfinder.api.matzip.controller;
+
+import com.wanted.teamr.tastyfinder.api.exception.CustomException;
+import com.wanted.teamr.tastyfinder.api.exception.ErrorCode;
+import com.wanted.teamr.tastyfinder.api.matzip.dto.MatzipResponse;
+import com.wanted.teamr.tastyfinder.api.matzip.service.MatzipService;
+import com.wanted.teamr.tastyfinder.api.review.dto.ReviewResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = MatzipController.class)
+public class MatzipControllerMockTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    MatzipService matzipService;
+
+    @DisplayName("맛집 상세 정보 API")
+    @Nested
+    class GetMatzip {
+
+        @DisplayName("맛집 조회 시 맛집 상세 정보 응답을 보낸다.")
+        @WithMockUser
+        @Test
+        void getMatzipFound() throws Exception {
+            // given
+            Long matzipId = 1L;
+            List<ReviewResponse> reviewResponseList = new ArrayList<>();
+            ReviewResponse reviewResponse1 = ReviewResponse.builder()
+                    .reviewId(1L)
+                    .rating(5)
+                    .content("맛있어요").build();
+            ReviewResponse reviewResponse2 = ReviewResponse.builder()
+                    .reviewId(2L)
+                    .rating(1)
+                    .content("맛없어요").build();
+            reviewResponseList.add(reviewResponse1);
+            reviewResponseList.add(reviewResponse2);
+            MatzipResponse matzipResponse = MatzipResponse.builder()
+                    .matzipId(matzipId)
+                    .reviewList(reviewResponseList)
+                    .avgRating(3).build();
+            when(matzipService.getMatzip(matzipId)).thenReturn(matzipResponse);
+
+            // when, then
+            mockMvc.perform(get("/api/matzips/{matzipId}", matzipId))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.matzipId").value(1))
+                    .andExpect(jsonPath("$.avgRating").value(3))
+                    .andExpect(jsonPath("$.reviewList", hasSize(2)))
+                    .andExpect(jsonPath("$.reviewList").isArray())
+                    .andExpect(jsonPath("$.reviewList[0].reviewId").value(reviewResponse1.getReviewId()))
+                    .andExpect(jsonPath("$.reviewList[1].reviewId").value(reviewResponse2.getReviewId()));
+        }
+
+        @DisplayName("맛집을 찾을 수 없을 때 에러 응답을 보낸다.")
+        @WithMockUser
+        @Test
+        void getPostNotFound() throws Exception {
+            // given
+            Long matzipId = 100L;
+            when(matzipService.getMatzip(matzipId)).thenThrow(new CustomException(ErrorCode.MATZIP_NOT_FOUND));
+
+            // when, then
+            mockMvc.perform(get("/api/matzips/{matzipId}", matzipId))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorCode").value(ErrorCode.MATZIP_NOT_FOUND.name()))
+                    .andExpect(jsonPath("$.message").value(ErrorCode.MATZIP_NOT_FOUND.getMessage()));
+        }
+
+    }
+
+}

--- a/src/test/java/com/wanted/teamr/tastyfinder/api/matzip/controller/MatzipControllerMockTest.java
+++ b/src/test/java/com/wanted/teamr/tastyfinder/api/matzip/controller/MatzipControllerMockTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
@@ -25,6 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(controllers = MatzipController.class)
+@MockBean(JpaMetamodelMappingContext.class)
 public class MatzipControllerMockTest {
 
     @Autowired

--- a/src/test/java/com/wanted/teamr/tastyfinder/api/matzip/service/MatzipServiceMockTest.java
+++ b/src/test/java/com/wanted/teamr/tastyfinder/api/matzip/service/MatzipServiceMockTest.java
@@ -1,0 +1,87 @@
+package com.wanted.teamr.tastyfinder.api.matzip.service;
+
+import com.wanted.teamr.tastyfinder.api.exception.CustomException;
+import com.wanted.teamr.tastyfinder.api.exception.ErrorCode;
+import com.wanted.teamr.tastyfinder.api.matzip.domain.Matzip;
+import com.wanted.teamr.tastyfinder.api.matzip.repository.MatzipRepository;
+import com.wanted.teamr.tastyfinder.api.review.domain.Review;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class MatzipServiceMockTest {
+
+    @Mock
+    MatzipRepository matzipRepository;
+    @InjectMocks
+    MatzipService matzipService;
+
+
+    @DisplayName("맛집 상세 정보 API")
+    @Nested
+    class GetMatzip {
+
+        @DisplayName("맛집 조회 시 맛집 상세 정보 응답을 보낸다.")
+        @WithMockUser
+        @Test
+        void getMatzipFound() throws Exception {
+            // given
+            Long matzipId = 1L;
+            Matzip matzip = Matzip.builder()
+                    .totalRating(6)
+                    .reviewCount(2).build();
+            List<Review> reviewResponseList = new ArrayList<>();
+            Review review1 = Review.builder()
+                    .matzip(matzip)
+                    .rating(5)
+                    .content("맛있어요").build();
+            Review review2 = Review.builder()
+                    .matzip(matzip)
+                    .rating(1)
+                    .content("맛없어요").build();
+            reviewResponseList.add(review1);
+            reviewResponseList.add(review2);
+            given(matzipRepository.findById(matzipId)).willReturn(Optional.of(matzip));
+
+            // when
+            matzipService.getMatzip(matzipId);
+
+            // then
+            assertAll(
+                    () -> verify(matzipRepository).findById(matzipId)
+            );
+        }
+
+        @DisplayName("맛집을 찾을 수 없을 때 에러 응답을 보낸다.")
+        @WithMockUser
+        @Test
+        void getPostNotFound() throws Exception {
+            // given
+            Long matzipId = 100L;
+            given(matzipRepository.findById(matzipId)).willReturn(Optional.empty());
+
+            // when, then
+            assertThatThrownBy(() -> matzipService.getMatzip(matzipId))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCodeType")
+                    .isEqualTo(ErrorCode.MATZIP_NOT_FOUND);
+        }
+
+    }
+
+}


### PR DESCRIPTION
## 📃 설명

- resolves #7
- 

## 🔨 작업 내용

1. 맛집 상세 정보 API 구현
- 해당 맛집의 평가(Review)에 대한 리스트를 수정 순 내림차순하여 같이 반환한다.
- 평가 작성시 저장된 총 평점과 평가 개수를 이용하여 평점을 같이 반환한다.
2. 테스트 구현


## 💬 기타 사항
- 평가 리스트 반환 시 `@order` 이 아닌 JPQL 사용 -> 관련 정리 문서 추가 예정