### PR TITLE
setup #20: PR 추가 시 Discord 알림 설정

### DIFF
--- a/.github/workflows/notify-pr.yml
+++ b/.github/workflows/notify-pr.yml
@@ -2,30 +2,34 @@ name: Discord PR Notification
 
 on:
   pull_request:
-    types: [opened]
-
+    types: [opened, ready_for_review]
+    
 jobs:
   pr-notify-discord:
     runs-on: ubuntu-latest
     steps:
-      - name: Failed when draft state
-        if: github.event.pull_request.draft == 'true'
-        run: exit 1
+    - name: Failed when draft state
+      id: check
+      if: github.event.pull_request.draft == true
+      run: |
+        echo ${{ github.event.pull_request.draft }}
+        echo ${{ github.event.pull_request.state }}
+        exit 1
         
-      - name: Notify Discord
-        id: notify
-        run: |
-          JSON_DATA='{
-            "content": "😃 ${{ github.event.pull_request.user.login }}님이 새로운 PR을 생성했습니다.",
-            "embeds": [
-              {
-                "title": "${{ github.event.pull_request.title }}",
-                "description": "Branch : ${{ github.event.pull_request.head.ref }} -> ${{ github.event.pull_request.base.ref }}\nURL: ${{ github.event.pull_request.html_url }}",
-                "color": 3368703
-              }
-            ]
-          }'
-          curl -X POST \
-            -H 'Content-Type: application/json' \
-            -d "$JSON_DATA" \
-            ${{ secrets.DISCORD }}
+    - name: Notify Discord
+      id: notify
+      run: |
+        JSON_DATA='{
+          "content": "😃 ${{ github.event.pull_request.user.login }}님이 새로운 PR을 생성했습니다.",
+          "embeds": [
+            {
+              "title": "${{ github.event.pull_request.title }}",
+              "description": "Branch : ${{ github.event.pull_request.head.ref }} -> ${{ github.event.pull_request.base.ref }}\nURL: ${{ github.event.pull_request.html_url }}",
+              "color": 3368703
+            }
+          ]
+        }'
+        curl -X POST \
+          -H 'Content-Type: application/json' \
+          -d "$JSON_DATA" \
+          ${{ secrets.DISCORD }}

--- a/.github/workflows/notify-pr.yml
+++ b/.github/workflows/notify-pr.yml
@@ -1,0 +1,31 @@
+name: Discord PR Notification
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  pr-notify-discord:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Failed when draft state
+        if: github.event.pull_request.draft == 'true'
+        run: exit 1
+        
+      - name: Notify Discord
+        id: notify
+        run: |
+          JSON_DATA='{
+            "content": "😃 ${{ github.event.pull_request.user.login }}님이 새로운 PR을 생성했습니다.",
+            "embeds": [
+              {
+                "title": "${{ github.event.pull_request.title }}",
+                "description": "Branch : ${{ github.event.pull_request.head.ref }} -> ${{ github.event.pull_request.base.ref }}\nURL: ${{ github.event.pull_request.html_url }}",
+                "color": 3368703
+              }
+            ]
+          }'
+          curl -X POST \
+            -H 'Content-Type: application/json' \
+            -d "$JSON_DATA" \
+            ${{ secrets.DISCORD }}


### PR DESCRIPTION
## 📃 설명

- resolves #20 
- 

## 🔨 작업 내용

1.  github action 추가

## 💬 기타 사항

- 디스코드 웹훅 요청 스펙 보다가 PR 관련 작업할 때 시스템상 자동으로 팀원들에게 알려지면 좋을 것 같아서 추가 작업 해봤습니다
- 라벨 자동으로 달기, assign 자동으로 달기, merge할 때도 알림 설정을 하고 싶었는데 잘 안됨...
  - pr draft -> open 전환할 때와 바로 pr open할 때만 알림 되도록 일단 설정
- 이건 바로 merge 하겠습니다...