### PR TITLE
setup #38: springdoc 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,9 @@ dependencies {
 	// log4j2
 	implementation 'org.springframework.boot:spring-boot-starter-log4j2'
 	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
+
+	// spring-doc
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/config/SecurityConfig.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/config/SecurityConfig.java
@@ -28,11 +28,17 @@ public class SecurityConfig {
     private final AuthenticationEntryPoint authenticationEntryPoint;
     private final AccessDeniedHandler accessDeniedHandler;
 
+    // SpringDocConfig의 Bean으로부터 받아오는 값
+    private final String swaggerPath;
+    private final String apiDocPath;
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .authorizeHttpRequests(authorizeHttpRequest -> authorizeHttpRequest
                         .requestMatchers("/api/**").permitAll()
+                        .requestMatchers(swaggerPath).permitAll()
+                        .requestMatchers(apiDocPath).permitAll()
                         .anyRequest().authenticated()
                 )
                 .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/config/SpringDocConfig.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/config/SpringDocConfig.java
@@ -1,5 +1,8 @@
 package com.wanted.teamr.tastyfinder.api.config;
 
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.properties.SpringDocConfigProperties;
 import org.springframework.context.annotation.Bean;
@@ -33,6 +36,21 @@ public class SpringDocConfig {
     @Bean(name = "apiDocPath")
     public String getApiDocPath() {
         return springDocConfigProperties.getApiDocs().getPath() + "/**";
+    }
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("지리기반 맛집 추천 웹 서비스 API")
+                .description("본 서비스는 지리기반 맛집 추천 웹서비스입니다.</br>" +
+                        "사용자는 사용자 위치 기반으로 맛집을 추천 받고 해당 맛집의 상세 정보를 확인할 수 있습니다.")
+                .version("1.0.0");
     }
 
 }

--- a/src/main/java/com/wanted/teamr/tastyfinder/api/config/SpringDocConfig.java
+++ b/src/main/java/com/wanted/teamr/tastyfinder/api/config/SpringDocConfig.java
@@ -1,0 +1,38 @@
+package com.wanted.teamr.tastyfinder.api.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.properties.SpringDocConfigProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class SpringDocConfig {
+
+    private final SpringDocConfigProperties springDocConfigProperties;
+
+    /**
+     * swagger ui 웹 페이지 주소: /swagger-ui/index.html
+     * <p>
+     * swagger ui 웹 페이지 리소스(js, css 등) 주소: /swagger-ui/**
+     *
+     * @return swagger-ui 웹 페이지, 웹 페이지를 위한 리소스 모두를 포함하는 주소 반환
+     */
+    @Bean(name = "swaggerPath")
+    public String getSwaggerPath() {
+        return "/swagger-ui/**";
+    }
+
+    /**
+     * api doc 주소: configuraiton file의 {springdoc.api-docs.path}
+     * <p>
+     * swagger-ui에서 요청하는 리소스(swagger-config 등) 주소: {springdoc.api-docs.path}/**
+     *
+     * @return api doc 주소와 그 외 swagger-ui에서 요청하는 리소스 모두를 포함하는 주소 반환
+     */
+    @Bean(name = "apiDocPath")
+    public String getApiDocPath() {
+        return springDocConfigProperties.getApiDocs().getPath() + "/**";
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,6 +25,7 @@ spring:
       - private/application-private.yml
       - redis.yml
       - sgg-csv-config.yml
+      - springdoc-config.yml
 
 logging:
   level:

--- a/src/main/resources/springdoc-config.yml
+++ b/src/main/resources/springdoc-config.yml
@@ -1,0 +1,3 @@
+springdoc:
+  api-docs:
+    path: /api-docs


### PR DESCRIPTION
## 📃 설명

- resolves #38 
- Swagger 공통 셋업

## 🔨 작업 내용

1. springdoc 라이브러리를 추가했습니다.
2. SpringDoc을 위한 전용 Configuration 파일을 추가했습니다.
    - swagger 웹 페이지, open api 문서 페이지를 정상적으로 표시하기 위한 security 통과 경로를 계산합니다.
    - 해당 경로를 각 bean으로 선언하여 SecurityConfig에서 주입받아 해당 경로를 permit 하였습니다.
3. spring-doc의 경로는 spring-doc-config의 파일을 통해 제어할 수 있습니다.
4. swagger 웹 페이지의 경로는 spring-doc-config를 통한 제어에 실패했습니다. 일단은 기본 경로인 /swagger-ui/index.html 로 웹 페이지에 접근할 수 있습니다.

## 💬 기타 사항

- /swagger-ui/index.html 경로를 통해 swagger 웹 페이지에 접근할 수 있습니다.
- /api-doc 경로를 통해 open api 문서에 접근할 수 있습니다.